### PR TITLE
Remove old fix

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -279,8 +279,6 @@ set_var EASYRSA_DIGEST "sha384"" > vars
 	echo "port $PORT
 proto udp
 dev tun
-sndbuf 0
-rcvbuf 0
 ca ca.crt
 cert server.crt
 key server.key
@@ -415,8 +413,6 @@ crl-verify crl.pem" >> /etc/openvpn/server.conf
 	echo "client
 dev tun
 proto udp
-sndbuf 0
-rcvbuf 0
 remote $IP $PORT
 resolv-retry infinite
 nobind


### PR DESCRIPTION
This fix was intended to overcome hardcoded buffers values in old OpenVPN revisions (see https://www.lowendtalk.com/discussion/40099/why-openvpn-is-so-slow-cool-story). This is not needed anymore, as OpenVPN now use OS buffers (see https://community.openvpn.net/openvpn/ticket/461 and https://community.openvpn.net/openvpn/changeset/c72dbb8b470ab7b25fc74e41aed4212db48a9d2f/). It should lead to better performances over fast networks.

Signed-off-by: Florian STOSSE contact@harvester.fr
