### PR TITLE
Support UFW and avoid DNS leak on windows

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -397,7 +397,7 @@ tls-auth tls-auth.key 0" >> /etc/openvpn/server.conf
 		ufw allow $PORT/udp
 		if [[ "$FORWARD_TYPE" = '1' ]]; then
 			sed -i '1s/^/##OPENVPN_START\n*nat\n:POSTROUTING ACCEPT [0:0]\n-A POSTROUTING -s 10.8.0.0\/24 -o eth0 -j MASQUERADE\nCOMMIT\n##OPENVPN_END\n\n/' /etc/ufw/before.rules
-			sed -ie 's/^DEFAULT_FORWARD_POLICY\s*=\s*/DEFAULT_FORWARD_POLICY="ACCEPT"\n#before ovpn: /' /etc/default/ufw
+			sed -ie 's/^DEFAULT_FORWARD_POLICY\s*=\s*/DEFAULT_FORWARD_POLICY="ACCEPT"\n#before openvpn: /' /etc/default/ufw
 		fi
 	fi
 	if iptables -L | grep -qE 'REJECT|DROP'; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -450,6 +450,7 @@ persist-tun
 remote-cert-tls server
 cipher AES-256-CBC
 auth SHA512
+block-outside-dns
 tls-version-min 1.2
 tls-client" > /etc/openvpn/client-common.txt
 	if [[ "$VARIANT" = '1' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -466,7 +466,7 @@ persist-tun
 remote-cert-tls server
 cipher AES-256-CBC
 auth SHA512
-block-outside-dns
+setenv opt block-outside-dns
 tls-version-min 1.2
 tls-client" > /etc/openvpn/client-common.txt
 	if [[ "$VARIANT" = '1' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -134,6 +134,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			if [[ "$REMOVE" = 'y' ]]; then
 				PORT=$(grep '^port ' /etc/openvpn/server.conf | cut -d " " -f 2)
 				if ufw status | grep -qw active; then
+					ufw delete allow $PORT/udp
 					sed -i '/^##OPENVPN_START/,/^##OPENVPN_END/d' /etc/ufw/before.rules
 					sed -i 's/^DEFAULT_FORWARD_POLICY="ACCEPT" #before ovpn: /DEFAULT_FORWARD_POLICY=/g' /etc/default/ufw
 				fi
@@ -391,6 +392,9 @@ tls-auth tls-auth.key 0" >> /etc/openvpn/server.conf
 		firewall-cmd --zone=trusted --add-source=10.8.0.0/24
 		firewall-cmd --permanent --zone=public --add-port=$PORT/udp
 		firewall-cmd --permanent --zone=trusted --add-source=10.8.0.0/24
+	fi
+	if ufw status | grep -qw active; then
+		ufw allow $PORT/udp
 	fi
 	if iptables -L | grep -qE 'REJECT|DROP'; then
 		# If iptables has at least one REJECT rule, we asume this is needed.

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -136,7 +136,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				if ufw status | grep -qw active; then
 					ufw delete allow $PORT/udp
 					sed -i '/^##OPENVPN_START/,/^##OPENVPN_END/d' /etc/ufw/before.rules
-					sed -i 's/^DEFAULT_FORWARD_POLICY="ACCEPT" #before ovpn: /DEFAULT_FORWARD_POLICY=/g' /etc/default/ufw
+					sed -i '/^DEFAULT_FORWARD/{N;s/DEFAULT_FORWARD_POLICY="ACCEPT"\n#before openvpn: /DEFAULT_FORWARD_POLICY=/}' /etc/default/ufw
 				elif pgrep firewalld; then
 					# Using both permanent and not permanent rules to avoid a firewalld reload.
 					firewall-cmd --zone=public --remove-port=$PORT/udp
@@ -397,7 +397,7 @@ tls-auth tls-auth.key 0" >> /etc/openvpn/server.conf
 		ufw allow $PORT/udp
 		if [[ "$FORWARD_TYPE" = '1' ]]; then
 			sed -i '1s/^/##OPENVPN_START\n*nat\n:POSTROUTING ACCEPT [0:0]\n-A POSTROUTING -s 10.8.0.0\/24 -o eth0 -j MASQUERADE\nCOMMIT\n##OPENVPN_END\n\n/' /etc/ufw/before.rules
-			sed -ie 's/^DEFAULT_FORWARD_POLICY\s*=\s*/DEFAULT_FORWARD_POLICY="ACCEPT" #before ovpn: /g' /etc/default/ufw
+			sed -ie 's/^DEFAULT_FORWARD_POLICY\s*=\s*/DEFAULT_FORWARD_POLICY="ACCEPT"\n#before ovpn: /' /etc/default/ufw
 		fi
 	fi
 	if iptables -L | grep -qE 'REJECT|DROP'; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -137,13 +137,14 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 					ufw delete allow $PORT/udp
 					sed -i '/^##OPENVPN_START/,/^##OPENVPN_END/d' /etc/ufw/before.rules
 					sed -i 's/^DEFAULT_FORWARD_POLICY="ACCEPT" #before ovpn: /DEFAULT_FORWARD_POLICY=/g' /etc/default/ufw
-				fi
-				if pgrep firewalld; then
+				elif pgrep firewalld; then
 					# Using both permanent and not permanent rules to avoid a firewalld reload.
 					firewall-cmd --zone=public --remove-port=$PORT/udp
 					firewall-cmd --zone=trusted --remove-source=10.8.0.0/24
 					firewall-cmd --permanent --zone=public --remove-port=$PORT/udp
 					firewall-cmd --permanent --zone=trusted --remove-source=10.8.0.0/24
+					firewall-cmd --zone=trusted --remove-masquerade
+					firewall-cmd --permanent --zone=trusted --remove-masquerade
 				fi
 				if iptables -L | grep -qE 'REJECT|DROP'; then
 					sed -i "/iptables -I INPUT -p udp --dport $PORT -j ACCEPT/d" $RCLOCAL


### PR DESCRIPTION
This PR does the following:

1) uses a new feature on OpenVPN 2.3.9 which avoids a [DNS leak for clients running Windows](https://community.openvpn.net/openvpn/ticket/605). It might be worth double checking that clients on other platforms and older openvpn versions are unaffected, but they should ignore unknown config options (an alternative is to push the setting from the server).

2) adds configuration for users running [UFW](https://help.ubuntu.com/community/UFW), and adds rules to unblock the NAT masquerading that needs to happen from the openvpn subnet to the gateway (in MASQUERADE mode). Changes are described under ufw [here](https://www.digitalocean.com/community/tutorials/how-to-set-up-an-openvpn-server-on-ubuntu-14-04).

3) adds rule to firewalld to unblock masquerading when relevant (untested). Relevant config referenced [here](http://unix.stackexchange.com/a/149193).
