### PR TITLE
Two times "EASYRSA_KEY_SIZE"

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -285,13 +285,11 @@ else
 	# If the user selected the fast, less hardened version
 	if [[ "$VARIANT" = '1' ]]; then
 		echo "set_var EASYRSA_KEY_SIZE 2048
-set_var EASYRSA_KEY_SIZE 2048
 set_var EASYRSA_DIGEST "sha256"" > vars
 	fi
 	# If the user selected the relatively slow, ultra hardened version
 	if [[ "$VARIANT" = '2' ]]; then
 		echo "set_var EASYRSA_KEY_SIZE 4096
-set_var EASYRSA_KEY_SIZE 4096
 set_var EASYRSA_DIGEST "sha384"" > vars
 	fi
 	# Create the PKI, set up the CA, the DH params and the server + client certificates


### PR DESCRIPTION
I see two times "EASYRSA_KEY_SIZE" in your script.

I don't test it, but I think it works with my modification.

How about the DH params generated? Is the key size equal to "EASYRSA_KEY_SIZE" too?

Thanks
